### PR TITLE
fix: handle packet error

### DIFF
--- a/device.go
+++ b/device.go
@@ -45,6 +45,9 @@ type Device interface {
 	// ExtendedScan starts scanning. Duplicated advertisements will be filtered out if allowDup is set to false.
 	ExtendedScan(ctx context.Context, allowDup bool, h ExtendedAdvHandler) error
 
+	// Reset
+	Reset(ctx context.Context) error
+
 	// Dial ...
 	Dial(ctx context.Context, a Addr) (Client, error)
 }

--- a/examples/basic/extended_scanner/main.go
+++ b/examples/basic/extended_scanner/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/go-ble/ble/examples/lib/dev"
+	"github.com/go-ble/ble/linux/hci"
 	"log"
 	"time"
 
@@ -28,8 +29,13 @@ func main() {
 	ble.SetDefaultDevice(d)
 	// ExtendedScan for specified durantion, or until interrupted by user.
 	fmt.Printf("ExtendedScaning for %s...\n", *du)
-	ctx := ble.WithSigHandler(context.WithTimeout(context.Background(), *du))
-	chkErr(ble.ExtendedScan(ctx, *dup, advHandler, nil))
+	for i := 0; i < 3; i++ {
+		ctx := ble.WithSigHandler(context.WithTimeout(context.Background(), *du))
+		err = ble.ExtendedScan(ctx, *dup, advHandler, nil)
+		if errors.Cause(err) == hci.ErrHCIHandlePacket {
+			chkErr(ble.Reset(ctx))
+		}
+	}
 }
 
 func advHandler(a ble.ExtendedAdvertisement) {

--- a/gatt.go
+++ b/gatt.go
@@ -120,6 +120,16 @@ func ExtendedScan(ctx context.Context, allowDup bool, h ExtendedAdvHandler, f Ad
 	return defaultDevice.ExtendedScan(ctx, allowDup, h2)
 }
 
+// Reset
+func Reset(ctx context.Context) error {
+	if defaultDevice == nil {
+		return ErrDefaultDevice
+	}
+	defer untrap(trap(ctx))
+
+	return defaultDevice.Reset(ctx)
+}
+
 // Find ...
 func Find(ctx context.Context, allowDup bool, f AdvFilter) ([]Advertisement, error) {
 	if defaultDevice == nil {

--- a/linux/device.go
+++ b/linux/device.go
@@ -246,6 +246,8 @@ func (d *Device) Scan(ctx context.Context, allowDup bool, h ble.AdvHandler) erro
 	case <-ctx.Done():
 	case <-d.HCI.Done():
 		return d.HCI.Error()
+	case <-d.HCI.Cancel():
+		return d.HCI.Error()
 	}
 	d.HCI.StopScanning()
 	return ctx.Err()
@@ -259,7 +261,13 @@ func (d *Device) ExtendedScan(ctx context.Context, allowDup bool, h ble.Extended
 	if err := d.HCI.ExtendedScan(allowDup); err != nil {
 		return err
 	}
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-d.HCI.Done():
+		return d.HCI.Error()
+	case <-d.HCI.Cancel():
+		return d.HCI.Error()
+	}
 	d.HCI.StopExtendedScan()
 	return ctx.Err()
 }

--- a/linux/device.go
+++ b/linux/device.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log"
+	"time"
 
 	"github.com/go-ble/ble"
 	"github.com/go-ble/ble/linux/att"
@@ -97,7 +98,9 @@ func loop(dev *hci.HCI, s *gatt.Server, mtu int) {
 			if err != io.EOF {
 				log.Printf("can't accept: %s", err)
 			}
-			return
+			log.Printf("go-ble workaround: sleep 15 seconds and retry. Error: %s", err)
+			time.Sleep(15 * time.Second)
+			continue
 		}
 
 		// Initialize the per-connection cccd values.

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -400,8 +400,6 @@ func (h *HCI) send(c Command) ([]byte, error) {
 	return ret, err
 }
 
-var count = 0
-
 func (h *HCI) sktLoop() {
 	b := make([]byte, 4096)
 	defer close(h.done)

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -440,9 +440,9 @@ func (h *HCI) sktLoop() {
 				h.skt = skt
 
 				// notify canceling to send hci command
+				h.err = ErrHCIHandlePacket
 				close(h.cancel)
 				h.cancel = make(chan bool)
-				h.err = ErrHCIHandlePacket
 				continue
 			}
 		}

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -430,6 +430,7 @@ func (h *HCI) sktLoop() {
 				}
 
 				// create hci socket again
+				h.err = ErrHCIHandlePacket
 				time.Sleep(3 * time.Second)
 				skt, err := socket.NewSocket(h.id)
 				if err != nil {
@@ -438,7 +439,6 @@ func (h *HCI) sktLoop() {
 				h.skt = skt
 
 				// notify canceling to send hci command
-				h.err = ErrHCIHandlePacket
 				close(h.cancel)
 				h.cancel = make(chan bool)
 				continue

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -3,7 +3,6 @@ package hci
 import (
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"strings"
 	"sync"
@@ -422,11 +421,12 @@ func (h *HCI) sktLoop() {
 			if strings.HasPrefix(err.Error(), "unsupported vendor packet:") {
 				_ = logger.Error("skt: %v", err)
 			} else {
-				log.Printf("skt: %v", err)
+				_ = logger.Warn("skt: %v", err)
 				// close current hci socket
-				err = h.Close()
+				err = h.skt.Close()
 				if err != nil {
-					return
+					_ = logger.Warn("can't close socket on sktLoop: %v", err)
+					continue
 				}
 
 				// create hci socket again

--- a/linux/hci/socket/socket_test.go
+++ b/linux/hci/socket/socket_test.go
@@ -1,0 +1,46 @@
+package socket
+
+import (
+	"testing"
+)
+
+// TestSocketIsClosed verifies the behavior of the IsClosed() method.
+// It checks that IsClosed() returns false when the socket is open and
+// true after the channel is closed.
+func TestSocketIsClosed(t *testing.T) {
+	// Create a new Socket which is initially not closed.
+	s := &Socket{
+		closed: make(chan struct{}),
+	}
+
+	// Verify that IsClosed() returns false for an open socket.
+	if s.IsClosed() {
+		t.Errorf("Expected socket to be open, but IsClosed() returned true")
+	}
+
+	// Close the channel to simulate closing the socket.
+	close(s.closed)
+
+	// After closing the channel, IsClosed() should return true.
+	if !s.IsClosed() {
+		t.Errorf("Expected socket to be closed, but IsClosed() returned false")
+	}
+
+	// Calling Close() again should have no effect and should not produce an error.
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close called again returned error: %v", err)
+	}
+
+	// IsClosed() should still return true after attempting to close again.
+	if !s.IsClosed() {
+		t.Errorf("Expected socket to still be closed, but IsClosed() returned false")
+	}
+
+	// Reassign a new channel to simulate opening the socket again.
+	s.closed = make(chan struct{})
+
+	// Now IsClosed() should return false again for the "reopened" socket.
+	if s.IsClosed() {
+		t.Errorf("Expected socket to be open, but IsClosed() returned true")
+	}
+}


### PR DESCRIPTION
- Processing is cancelled when an unhandled evt is received.
- Return `ErrHCIHandlePacket` when a Cancel event is received in the process of sending to HCI.